### PR TITLE
FIX: Added back background image size

### DIFF
--- a/css/LeftAndMainYouTubeField.css
+++ b/css/LeftAndMainYouTubeField.css
@@ -2,5 +2,6 @@
     background-image: url('../images/field-icon-youtube.png');
     background-position: 6px center;
     background-repeat: no-repeat;
+    background-size: 28px 20px;
     padding-left: 40px;
 }


### PR DESCRIPTION
Sorry, made one small mistake, the `background-size` is still needed, as there's a `background-size: 100%;` somewhere that stretches the icon image.
