### PR TITLE
Support guzzle v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require": {
 		"silverstripe/framework": "^4",
-		"guzzlehttp/guzzle": "~6.0"
+		"guzzlehttp/guzzle": "^6.0 || ^7.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Kia ora, 

Can the version requirement for Guzzle be extended to include v7? 

silverstripe/silverstripe-framework as of v4.11, requires Guzzle v7.

https://github.com/silverstripe/silverstripe-framework/blob/4.11.0/composer.json